### PR TITLE
Update log message to include hotkey from config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -297,7 +297,10 @@ fn main() -> Result<()> {
     };
 
     stream.play()?;
-    println!("[SS9K] Stream playing. Waiting for F12...");
+    println!(
+        "[SS9K] Stream playing. Waiting for [{}]...",
+        &config.load().hotkey
+    );
 
     let (audio_tx, audio_rx) = mpsc::channel::<Vec<f32>>();
 


### PR DESCRIPTION
The old message listed F12 as the hotkey even while it was changed in the config.